### PR TITLE
Add STRtree spatial indexing to reduce O(n²) neighbor assignment

### DIFF
--- a/formatData/atomicBlock.py
+++ b/formatData/atomicBlock.py
@@ -1,3 +1,4 @@
+from shapely import STRtree
 from shapely.geometry import MultiPolygon
 from censusData.censusBlock import CensusBlock
 from exportData.displayShapes import plotPolygons
@@ -32,10 +33,16 @@ class AtomicBlock(CensusContainer, GraphObject):
         return all(block.isWater for block in self.children)
 
 
-def assignNeighborBlocksFromCandidateBlocks(block, candidateBlocks, progressObject=None):
+def assignNeighborBlocksFromCandidateBlocks(block, candidateBlocks, progressObject=None,
+                                            candidateTree=None):
     block.clearNeighborGraphObjects()
     neighborBlocks = []
-    for candidateBlock in candidateBlocks:
+    if candidateTree is not None:
+        indices = candidateTree.query(block.geometry, predicate='intersects')
+        nearby = [candidateBlocks[i] for i in indices]
+    else:
+        nearby = candidateBlocks
+    for candidateBlock in nearby:
         if candidateBlock is not block:
             if intersectingGeometries(block, candidateBlock):
                 neighborBlocks.append(candidateBlock)

--- a/formatData/redistrictingGroup.py
+++ b/formatData/redistrictingGroup.py
@@ -492,12 +492,15 @@ class RedistrictingGroup(BlockBorderGraph, GraphObject):
                 raise RuntimeError("Some blocks have neighbor connections with block outside the redistricting group")
 
     def assignNeighboringBlocksToBlocks(self):
+        from shapely import STRtree
+        candidateTree = STRtree([child.geometry for child in self.children])
         with tqdm(total=len(self.children)) as pbar:
             threadPool = Pool(4)
             threadPool.starmap(assignNeighborBlocksFromCandidateBlocks,
                                zip(self.children,
                                    repeat(self.children),
-                                   repeat(pbar)))
+                                   repeat(pbar),
+                                   repeat(candidateTree)))
 
     def __lt__(self, other):
         if isinstance(other, RedistrictingGroup):
@@ -668,31 +671,40 @@ def assignNeighboringRedistrictingGroupsForRedistrictingGroups(redistrictingGrou
 def assignNeighboringRedistrictingGroupsToRedistrictingGroups(changedRedistrictingGroups,
                                                               allNeighborCandidates,
                                                               shouldAttachOrphans=True):
+    from shapely import STRtree
+    candidateList = list(allNeighborCandidates)
+    candidateSet = set(candidateList)
+
     tqdm.write('\n')
     tqdm.write('*** Removing Outdated Neighbor Connections ***')
-    with tqdm(total=len(allNeighborCandidates)) as pbar:
-        # remove outdated neighbor connections
-        for redistrictingGroup in allNeighborCandidates:
-            outdatedNeighborConnections = [neighbor for neighbor in redistrictingGroup.allNeighbors
-                                           if neighbor not in allNeighborCandidates]
+    with tqdm(total=len(candidateList)) as pbar:
+        for redistrictingGroup in candidateList:
+            outdatedNeighborConnections = [n for n in redistrictingGroup.allNeighbors
+                                           if n not in candidateSet]
             if outdatedNeighborConnections:
                 redistrictingGroup.removeNeighbors(outdatedNeighborConnections)
             pbar.update(1)
 
+    candidateTree = STRtree([g.geometry for g in candidateList])
+
     tqdm.write('\n')
     tqdm.write('*** Assign Neighbors to Changed Redistricting Groups ***')
     with tqdm(total=len(changedRedistrictingGroups)) as pbar:
-        # assign neighbors to changed groups and those that they touch
         for changedRedistrictingGroup in changedRedistrictingGroups:
             changedRedistrictingGroup.clearNeighborGraphObjects()
-            for redistrictingGroupToCheckAgainst in [aGroup for aGroup in allNeighborCandidates
-                                                     if aGroup is not changedRedistrictingGroup]:
-                if intersectingGeometries(changedRedistrictingGroup, redistrictingGroupToCheckAgainst):
+            indices = candidateTree.query(changedRedistrictingGroup.geometry,
+                                          predicate='intersects')
+            for i in indices:
+                redistrictingGroupToCheckAgainst = candidateList[i]
+                if redistrictingGroupToCheckAgainst is changedRedistrictingGroup:
+                    continue
+                if intersectingGeometries(changedRedistrictingGroup,
+                                          redistrictingGroupToCheckAgainst):
                     changedRedistrictingGroup.addNeighbors([redistrictingGroupToCheckAgainst])
                     redistrictingGroupToCheckAgainst.addNeighbors([changedRedistrictingGroup])
             pbar.update(1)
 
-        unionOfRedistrictingGroups = list(set(changedRedistrictingGroups) | set(allNeighborCandidates))
+        unionOfRedistrictingGroups = list(set(changedRedistrictingGroups) | set(candidateList))
 
     if shouldAttachOrphans:
         attachOrphanRedistrictingGroupsToClosestNeighbor(unionOfRedistrictingGroups)

--- a/redistrict/district.py
+++ b/redistrict/district.py
@@ -580,9 +580,12 @@ def mergeCandidatesIntoPreviousGroups(candidates):
                     # assign block neighbors to former border blocks
                     tqdm.write('      *** Starting a merge with {0} border blocks and {1} total blocks ***'.format(
                         len(allBorderBlocks), len(allBlocks)))
+                    from shapely import STRtree
+                    candidateTree = STRtree([b.geometry for b in allBlocks])
                     for formerBorderBlock in allBorderBlocks:
                         assignNeighborBlocksFromCandidateBlocks(block=formerBorderBlock,
-                                                                candidateBlocks=allBlocks)
+                                                                candidateBlocks=allBlocks,
+                                                                candidateTree=candidateTree)
 
                     contiguousRegions = findContiguousGroupsOfGraphObjects(allBlocks)
 
@@ -590,9 +593,11 @@ def mergeCandidatesIntoPreviousGroups(candidates):
                     for contiguousRegion in contiguousRegions:
                         contiguousRegionGroup = RedistrictingGroup(childrenBlocks=contiguousRegion)
                         # assign block neighbors to former border blocks
+                        candidateTree = STRtree([b.geometry for b in contiguousRegionGroup.children])
                         for borderBlock in contiguousRegionGroup.borderChildren:
                             assignNeighborBlocksFromCandidateBlocks(block=borderBlock,
-                                                                    candidateBlocks=contiguousRegionGroup.children)
+                                                                    candidateBlocks=contiguousRegionGroup.children,
+                                                                    candidateTree=candidateTree)
                         contiguousRegionGroup.validateBlockNeighbors()
                         mergedRedistrictingGroupsForPrevious.append(contiguousRegionGroup)
                     mergedRedistrictingGroups.extend(mergedRedistrictingGroupsForPrevious)


### PR DESCRIPTION
## Summary
- Builds a Shapely 2.0 `STRtree` once per candidate list in each of the three neighbor-assignment hotspots, pre-filtering candidates via bounding-box + `intersects` predicate before the existing `intersectingGeometries()` call
- Reduces block neighbor assignment from O(n²·geom) to O(n log n + n·k·geom) per county — the dominant cost in `prepareBlockGraphsForRedistrictingGroups`
- Same optimization applied to `assignNeighboringRedistrictingGroupsToRedistrictingGroups` (county-level graph) and the two border-block re-assignment loops in `district.py` during recursive splitting
- Converts outdated-neighbor removal scan to use a `set` for O(1) membership testing
- Behavior is identical — STRtree `predicate='intersects'` is a strict superset of what `intersectingGeometries()` returns True for, so no neighbors are ever missed
- All 67 tests pass

## Test plan
- [x] `python -m pytest tests/ -v` — 67/67 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)