### PR TITLE
Add 2020 census support and district comparison

### DIFF
--- a/censusData/getBlockData.py
+++ b/censusData/getBlockData.py
@@ -1,3 +1,4 @@
+import sys
 from census import Census
 from us import states
 import math
@@ -35,12 +36,19 @@ def getCountiesInState(stateFIPSCode, maxNumberOfCounties=math.inf, specificCoun
 
 
 def getBlocksInCounty(stateFIPSCode, countyFIPSCode):
-    # DEPRECATED: P0010001 is the total population as defined by: https://api.census.gov/data/2010/sf1/variables.html
-    # The API now defaults to: https://api.census.gov/data/2010/dec/sf1/variables.html
-    # Which now uses: P001001 for total population
-    countyBlocks = censusRequest.sf1.get(fields=('P001001'),
-                                         geo={'for': 'block:*', 'in': 'state:{0} county:{1}'.format(
-                                             stateFIPSCode, countyFIPSCode)})
+    if censusYear == 2020:
+        countyBlocks = censusRequest.pl.get(fields=('P1_001N'),
+                                            geo={'for': 'block:*', 'in': 'state:{0} county:{1}'.format(
+                                                stateFIPSCode, countyFIPSCode)})
+        for block in countyBlocks:
+            block['P001001'] = block.pop('P1_001N')  # normalize field name for downstream use
+    else:
+        # DEPRECATED: P0010001 is the total population as defined by: https://api.census.gov/data/2010/sf1/variables.html
+        # The API now defaults to: https://api.census.gov/data/2010/dec/sf1/variables.html
+        # Which now uses: P001001 for total population
+        countyBlocks = censusRequest.sf1.get(fields=('P001001'),
+                                             geo={'for': 'block:*', 'in': 'state:{0} county:{1}'.format(
+                                                 stateFIPSCode, countyFIPSCode)})
     return countyBlocks
 
 
@@ -74,8 +82,10 @@ def allGeoDataForEachBlock(countyInfoList, existingBlockData):
             startTimeForProcessingCounty = time.localtime()
             countyFIPSCode = county['county']
 
+            TIGER_BLOCK_LAYER = 10 if censusYear == 2020 else 14
+            TIGER_SERVICE = f'Census{censusYear}/tigerWMS_Census{censusYear}'
             blockGeometries = EsriDumper(
-                url='https://tigerweb.geo.census.gov/arcgis/rest/services/Census2010/tigerWMS_Census2010/MapServer/14',
+                url=f'https://tigerweb.geo.census.gov/arcgis/rest/services/{TIGER_SERVICE}/MapServer/{TIGER_BLOCK_LAYER}',
                 extra_query_args={'where': 'STATE=\'{0}\' AND COUNTY=\'{1}\''.format(stateFIPSCode, countyFIPSCode),
                                   'orderByFields': 'TRACT, BLKGRP, BLOCK'},
                 timeout=120)  # extending timeout because there were some long load times
@@ -126,8 +136,10 @@ def allGeoDataForEachCounty(existingCountyData):
                 whereArgument = '{0} OR '.format(whereArgument)
         whereArgument = '{0})'.format(whereArgument)
 
+        TIGER_COUNTY_LAYER = 82 if censusYear == 2020 else 90
+        TIGER_SERVICE = f'Census{censusYear}/tigerWMS_Census{censusYear}'
         countyGeometries = EsriDumper(
-            url='https://tigerweb.geo.census.gov/arcgis/rest/services/Census2010/tigerWMS_Census2010/MapServer/90',
+            url=f'https://tigerweb.geo.census.gov/arcgis/rest/services/{TIGER_SERVICE}/MapServer/{TIGER_COUNTY_LAYER}',
             extra_query_args={'where': whereArgument,
                               'orderByFields': 'COUNTY'})
         # https://github.com/openaddresses/pyesridump
@@ -155,7 +167,7 @@ def allGeoDataForEachCounty(existingCountyData):
 
 stateAbbreviation = 'MI'
 stateInfo = states.lookup(stateAbbreviation)
-censusYear = 2010
+censusYear = int(sys.argv[1]) if len(sys.argv) > 1 else 2010
 descriptionToWorkWith = 'All'
 
 censusRequest = Census(apiKeys.censusAPIKey, year=censusYear)

--- a/compareDistricts.py
+++ b/compareDistricts.py
@@ -1,0 +1,12 @@
+from us import states
+from exportData.displayShapes import plotDistrictComparison
+from exportData.exportData import loadDataFromFileWithDescription
+
+stateInfo = states.lookup('MI')
+descriptionToWorkWith = 'All'
+
+districts2010 = loadDataFromFileWithDescription(censusYear=2010, stateName=stateInfo.name,
+                                                descriptionOfInfo=f'{descriptionToWorkWith}-FederalDistricts')
+districts2020 = loadDataFromFileWithDescription(censusYear=2020, stateName=stateInfo.name,
+                                                descriptionOfInfo=f'{descriptionToWorkWith}-FederalDistricts')
+plotDistrictComparison(districts2010, districts2020)

--- a/exportData/displayShapes.py
+++ b/exportData/displayShapes.py
@@ -309,6 +309,25 @@ def plotDistricts(districts,
     pyplot.show()
 
 
+def plotDistrictComparison(districts2010, districts2020):
+    fig, (ax1, ax2) = pyplot.subplots(1, 2, figsize=(20, 10))
+    cmap = colormaps['tab20']
+    for ax, districts, title in [
+        (ax1, districts2010, '2010 Districts'),
+        (ax2, districts2020, '2020 Districts'),
+    ]:
+        for i, district in enumerate(districts):
+            color = cmap(i % 20)
+            for redistrictingGroup in district.children:
+                ax.add_patch(patch_from_polygon(redistrictingGroup.geometry,
+                                                facecolor=color, edgecolor='black', linewidth=0.5))
+        ax.autoscale()
+        ax.set_aspect('equal')
+        ax.set_title(title)
+    pyplot.tight_layout()
+    pyplot.show()
+
+
 def getColor(index):
     if index >= len(distinctColors):
         index -= len(distinctColors)

--- a/formatData/formatBlockData.py
+++ b/formatData/formatBlockData.py
@@ -1,3 +1,4 @@
+import sys
 from us import states
 from exportData.displayShapes import plotBlocksForRedistrictingGroups
 from exportData.exportData import saveDataToFileWithDescription,\
@@ -7,7 +8,7 @@ from formatData.redistrictingGroup import createRedistrictingGroupsWithAtomicBlo
 
 stateAbbreviation = 'MI'
 stateInfo = states.lookup(stateAbbreviation)
-censusYear = 2010
+censusYear = int(sys.argv[1]) if len(sys.argv) > 1 else 2010
 descriptionToWorkWith = 'All'
 
 censusData = loadDataFromFileWithDescription(censusYear=censusYear,

--- a/redistrict/createDistricts.py
+++ b/redistrict/createDistricts.py
@@ -1,3 +1,4 @@
+import sys
 from us import states
 from exportData.displayShapes import plotDistricts, plotPolygons
 from exportData.exportData import loadDataFromFileWithDescription, saveDataToFileWithDescription, \
@@ -7,7 +8,7 @@ from redistrict.district import createDistrictFromRedistrictingGroups, Weighting
 
 stateAbbreviation = 'MI'
 stateInfo = states.lookup(stateAbbreviation)
-censusYear = 2010
+censusYear = int(sys.argv[1]) if len(sys.argv) > 1 else 2010
 descriptionToWorkWith = 'All'
 numberOfDistricts = 110
 overallPercentageOffIdealAllowed = 0.0996


### PR DESCRIPTION
## Summary
- **2020 API support**: `getBlockData.py` now accepts a year argument (`python getBlockData.py 2020`), branching between the `sf1`/`pl` Census endpoints, normalizing the `P1_001N` field to `P001001`, and using the correct TIGER MapServer layers (block=10, county=82 for 2020; block=14, county=90 for 2010)
- **Year arg plumbing**: `formatBlockData.py` and `createDistricts.py` each accept an optional year arg (default 2010), so the full pipeline can be run for either year without code changes
- **Comparison visualization**: `displayShapes.py` gains `plotDistrictComparison()` which renders 2010 and 2020 district maps side by side using matplotlib subplots
- **New entry point**: `compareDistricts.py` loads both years' saved district results and calls the comparison function

## Test plan
- [ ] `python -m pytest tests/ -v` — all existing tests pass (no logic changes)
- [ ] `python censusData/getBlockData.py 2020` — downloads 2020 data, produces `~/Documents/2020-Michigan-AllBlockInfo.redistdata`
- [ ] `python formatData/formatBlockData.py 2020` — formats 2020 data
- [ ] `python redistrict/createDistricts.py 2020` — produces `~/Documents/2020-Michigan-All-FederalDistrictsInfo.redistdata`
- [ ] `python compareDistricts.py` — shows side-by-side 2010 vs 2020 Michigan district maps
- [ ] `python censusData/getBlockData.py` (no args) — 2010 pipeline still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)